### PR TITLE
Only reschedule the task identified by the id

### DIFF
--- a/src/cronj/data/scheduler.clj
+++ b/src/cronj/data/scheduler.clj
@@ -32,7 +32,7 @@
 
 (defn reschedule-task [tsc task-id schedule]
   (dosync
-   (ova/!> tsc [[:task :id task-id]]
+   (ova/!> tsc [[:task :id] task-id]
          (merge
           {:schedule  schedule
            :tab-array (set-tab-array-fn schedule)}))))

--- a/test/cronj/test_scheduler.clj
+++ b/test/cronj/test_scheduler.clj
@@ -32,6 +32,11 @@
       (ts/schedule-task tscb tk2 "* * * * * * *")
       (fact "should still have 2 tasks" (count tscb) => 2)
 
+      (ts/reschedule-task tscb :1 "0 * * * * * *")
+      (fact "only tk1 should be rescheduled"
+        (:schedule (ts/get-task tscb :1)) => "0 * * * * * *"
+        (:schedule (ts/get-task tscb :2)) => "* * * * * * *")
+
       (ts/unschedule-task tscb :2)
       (fact "should still have 1 task" (count tscb) => 1)
 


### PR DESCRIPTION
Fixes a bug where `scheduler/reschedule-task` will reschedule ALL of the tasks due to an incorrect Ova selector.
